### PR TITLE
Append body padding for smooth sticky transitions

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -36,11 +36,15 @@ angular.module('sticky', [])
 					scrollTop = (window.pageYOffset || doc.scrollTop)  - (doc.clientTop || 0);
 
 					if ( scrollTop >= stickyLine ){
+						if (!$elem.hasClass(stickyClass)) {
+							document.body.style.paddingTop = parseInt(window.getComputedStyle(document.body)['padding-top']) + $elem[0].offsetHeight + 'px';
+						}
 						$elem.addClass(stickyClass);
 						$elem.css('position', 'fixed');
 					} else {
 						$elem.removeClass(stickyClass);
 						$elem.css('position', initialPositionStyle);
+						document.body.style.paddingTop = parseInt(window.getComputedStyle(document.body)['padding-top']) - $elem[0].offsetHeight + 'px';
 					}
 				}
 


### PR DESCRIPTION
Adds the element's outer height to the `padding-top` of `body`, so that the scrolling doesn't stutter when an element is stickied.
