### PR TITLE
Remove window listeners when scope is destroyed

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -52,12 +52,19 @@ angular.module('sticky', [])
 					$timeout(setInitial);
 				}
 
+				// Remove the listeners when the scope is destroyed
+				//
+				function onDestroy(){
+					$window.off('scroll', checkSticky);
+					$window.off('resize', resize);
+				}
 
 				// Attach our listeners
 				//
+				$scope.$on('$destroy', onDestroy);
 				$window.on('scroll', checkSticky);
 				$window.on('resize', resize);
-				
+
 				setInitial();
 			});
 		},


### PR DESCRIPTION
Currently when the scope is destroyed and the sticky element is removed from the DOM the `window` listerners are left behind causing a potential memory leak.
