### PR TITLE
Add optional body class option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple, pure javascript (No jQuery required!) AngularJS directive to make elem
   * Recalculates element position on page load and on window resize
   * Clean: No classes are added, no jQuery is required, no CSS files or configuration is needed.
 
-  
+
 # Bower
 
 Install with bower with:
@@ -29,10 +29,13 @@ as a dependency. Use the directive as follows:
 To make the element stick within a certain offset of the top of the screen, you can provide an offset as follows:
 
     <div sticky offset="100"> I won't touch the top of your screen! </div>
-    
+
 If you want to customize the style while the element is sticky, we have an api for you too:
 
     <div sticky offset="100" sticky-class="imSoSticky"> Taste my gule! </div>
-    
-    
+
+And if you want to customize the body style while the element is sticky:
+
+    <div sticky offset="100" body-class="somethingIsSticky"> Taste my gule! </div>
+
 Cheers.

--- a/sticky.js
+++ b/sticky.js
@@ -5,14 +5,17 @@ angular.module('sticky', [])
 		restrict: 'A',
 		scope: {
 			offset: '@',
-			stickyClass: '@'
+			stickyClass: '@',
+			bodyClass: '@'
 		},
 		link: function($scope, $elem, $attrs){
 			$timeout(function(){
 				var offsetTop = $scope.offset || 0,
 					stickyClass = $scope.stickyClass || '',
+					bodyClass = $scope.bodyClass || '',
 					$window = angular.element(window),
 					doc = document.documentElement,
+					body = angular.element(document.body),
 					initialPositionStyle = $elem.css('position'),
 					stickyLine,
 					scrollTop;
@@ -38,9 +41,11 @@ angular.module('sticky', [])
 					if ( scrollTop >= stickyLine ){
 						$elem.addClass(stickyClass);
 						$elem.css('position', 'fixed');
+						body.addClass(bodyClass);
 					} else {
 						$elem.removeClass(stickyClass);
 						$elem.css('position', initialPositionStyle);
+						body.removeClass(bodyClass);
 					}
 				}
 
@@ -57,7 +62,7 @@ angular.module('sticky', [])
 				//
 				$window.on('scroll', checkSticky);
 				$window.on('resize', resize);
-				
+
 				setInitial();
 			});
 		},


### PR DESCRIPTION
Works the same as `stickyClass` but adds a class to the body instead. You can use this to style other elements on the page when something is sticky. For example, could be used to eliminate the visual jump when sticky elements are made `position:fixed`.
