### PR TITLE
Improved performance

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -29,7 +29,9 @@ angular.module('sticky', [])
 					initialPositionStyle = $elem.css('position'),
 					initialWidthStyle = $elem[0].offsetWidth,
 					stickyLine,
-					scrollTop;
+					scrollTop,
+					isSticky,
+					isPositionFixed;
 
 
 				// Set the top offset
@@ -54,12 +56,14 @@ angular.module('sticky', [])
 				//
 				function checkSticky(){
 					scrollTop = (window.pageYOffset || doc.scrollTop)  - (doc.clientTop || 0);
+					isSticky = scrollTop >= stickyLine && matchMedia('('+ mediaQuery +')').matches;
+					isPositionFixed = $elem.css('position') == 'fixed';
 
-					if ( scrollTop >= stickyLine && matchMedia('('+ mediaQuery +')').matches ){
+					if (isSticky && !isPositionFixed){
 						$elem.addClass(stickyClass);
 						$elem.css('position', 'fixed');
 						$elem.css('width', initialWidthStyle);
-					} else {
+					} else if (!isSticky && isPositionFixed) {
 						$elem.removeClass(stickyClass);
 						$elem.css('position', initialPositionStyle);
 					}


### PR DESCRIPTION
In the previous version we invoked functions element.css/addClass/removeClass every single time whenever the scrolling event has triggered. It's an extremely expensive operation because it forces reflow (recalculation) even if we haven't changed anything. It can be seen in complex layouts.
Now we call aforementioned functions only when we change the state of the sticky block.
