### PR TITLE
Fixed bug with dynamic width

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -83,9 +83,9 @@
 				stickyClass && $elem.addClass(stickyClass);
 
 				$elem
+					.css('width',    elem.offsetWidth+'px')
 					.css('position', 'fixed')
 					.css('top',      offset+'px')
-					.css('width',    initial.offsetWidth)
 					.css('margin-top',   0);
 
 			};
@@ -96,6 +96,7 @@
 				stickyClass && $elem.removeClass(stickyClass);
 
 				$elem
+					.css('width', initial.width ? initial.width : '')
 					.css('top',      initial.top)
 					.css('position', initial.position)
 					.css('margin-top',   initial.marginTop);
@@ -128,7 +129,7 @@
 					var initialOffsetWidth = elem.parentElement.offsetWidth
 						- parent.getPropertyValue('padding-right').replace("px", "")
 						- parent.getPropertyValue('padding-left').replace("px", "");
-					$elem.css("width", initialOffsetWidth);
+					$elem.css("width", initialOffsetWidth+"px");
 
 				}
 			};


### PR DESCRIPTION
In my ongoing project I have the sticky block with the width specified in percents so whenever we do "stick" we need to fixate it in "px". I see you implemented this case but with a couple of bugs.

When we "stick" our block we need to fixate it with the current width in "px" (not the initial width), in my case the width of the block can be different everytime.
And when we "unstick" it we need return everything how it was before.

Also you forgot to specify units of the sticky block on the resize event.
