### PR TITLE
Keep the left alignment

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -161,6 +161,7 @@
 					.css('width',      elem.offsetWidth+'px')
 					.css('position',   'fixed')
 					.css(anchor,       offset+'px')
+					.css('left',       absoluteLeft)
 					.css('margin-top', 0);
 
 				if ( anchor === 'bottom' ) {
@@ -184,6 +185,7 @@
 					.css('width',      '')
 					.css('top',        initialCSS.top)
 					.css('position',   initialCSS.position)
+					.css('left',       initialCSS.cssLeft)
 					.css('margin-top', initialCSS.marginTop);
 			}
 


### PR DESCRIPTION
This will keep the left alignment of the element. Without this, the element will not stick well using twitter bootstrap col-* for example.

For example, members column should stick and stay right:

![capture d ecran 2015-01-20 a 08 44 55](https://cloud.githubusercontent.com/assets/264403/5813627/b78337d6-a080-11e4-934f-c4f7189174ee.png)

but does not

![capture d ecran 2015-01-20 a 08 45 09](https://cloud.githubusercontent.com/assets/264403/5813635/c505c158-a080-11e4-90f6-766706ce59ad.png)
