### PR TITLE
Allow for complex media queries

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -119,7 +119,7 @@
 			function checkIfShouldStick() {
 				var scrollTop, shouldStick, scrollBottom, scrolledDistance;
 
-				if ( mediaQuery && !matchMedia('('+mediaQuery+')').matches) 
+				if ( mediaQuery && !(matchMedia('('+mediaQuery+')').matches || matchMedia(mediaQuery).matches) )
 					return;
 
 				if ( anchor === 'top' ) {


### PR DESCRIPTION
Originally, ngSticky supported simple media queries like `media-query="min-height: 768px"`. Because of the internal handling of this query (i.e. adding brackets) it was impossible to create more complex media queries like `media-query="(min-height: 768px) and (min-width:600px)"`. In that case ngSticky would test `((min-height: 768px) and (min-width:600px)` which always returns false due to too many brackets.

This commit fixes the issue with more complex media queries while maintaining backwards compatibility.