### PR TITLE
Update position of sticky element on window resize

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -70,6 +70,7 @@
 
 			function onResize() {
 				initialCSS.offsetWidth = elem.offsetWidth;
+				unstickElement();
 				checkIfShouldStick();
 				
 				if(isSticking){


### PR DESCRIPTION
When the window resizes horizontally, and the element is inside a responsive layout (i.e. Bootstrap) it horizontal position may change.
To update the element, it needs to be unstuck first, and then stuck again after it's properly positioned in the original container.