### PR TITLE
Adds placeholder to avoid jumping when element becomes sticky.

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -14,7 +14,7 @@
 		function linkFn($scope, $elem, $attrs) {
 			var mediaQuery, stickyClass, bodyClass, elem, $window, $body,
 				doc, initialCSS, initialStyle, isPositionFixed, isSticking,
-				stickyLine, offset, anchor, prevOffset, matchMedia;
+				stickyLine, offset, anchor, prevOffset, matchMedia, usePlaceholder, placeholder;
 
 			isPositionFixed = false;
 			isSticking      = false;
@@ -31,6 +31,8 @@
 			mediaQuery  = $attrs.mediaQuery  || false;
 			stickyClass = $attrs.stickyClass || '';
 			bodyClass   = $attrs.bodyClass   || '';
+
+			usePlaceholder = $attrs.useplaceholder == undefined ? false : true;
 
 			initialStyle = $elem.attr('style');
 
@@ -88,6 +90,10 @@
 				
 				if ( bodyClass ) {
 					$body.removeClass(bodyClass);
+				}
+
+				if ( placeholder ) {
+					placeholder.remove();
 				}
 			}
 
@@ -167,6 +173,14 @@
 				if ( anchor === 'bottom' ) {
 					$elem.css('margin-bottom', 0);
 				}
+
+				//create placeholder to avoid jump
+				if( usePlaceholder ) {
+					placeholder = angular.element("<div>");
+					var elemntsHeight = $elem.height();
+					placeholder.css("height", elemntsHeight + "px");
+					$elem.after(placeholder);
+				}
 			}
 
 			function unstickElement() {
@@ -187,6 +201,10 @@
 					.css('position',   initialCSS.position)
 					.css('left',       initialCSS.cssLeft)
 					.css('margin-top', initialCSS.marginTop);
+
+				if ( placeholder ) {
+					placeholder.remove();
+				}
 			}
 
 			function _getTopOffset (element) {


### PR DESCRIPTION
Without placeholder whole content jumps up when target element becomes sticky. Adding useplaceholder attribute to the target element will force the create of placeholder element when activating stikcness