### PR TITLE
Removed jQuery dependency

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -177,7 +177,7 @@
 				//create placeholder to avoid jump
 				if( usePlaceholder ) {
 					placeholder = angular.element("<div>");
-					var elemntsHeight = $elem.height();
+					var elemntsHeight = $elem[0].offsetHeight;
 					placeholder.css("height", elemntsHeight + "px");
 					$elem.after(placeholder);
 				}


### PR DESCRIPTION
With my last PR i have added a jquery dependency with 
```var elemntsHeight = $elem.height();```

Now it's removed
```var elemntsHeight = $elem[0].offsetHeight;```