### PR TITLE
Added confine to parent feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,10 @@ In order to enable sticky based on a media query:
 
     <div sticky media-query="min-width: 768px"> Won't be sticky on small screens! </div>
 
+And if you want to confine an element to it's parent, and let it 'bottom out' just add the confine attribute:
+
+    <div sticky offset="100" confine="true"> Will unstick and stick to bottom of parent element</div>
+
+> NOTE: The confine attribute will automagically assign it's parent a position: relative style in order to help with absolute positioning relative to the parent.
+ 
 Cheers.

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -18,7 +18,7 @@
 		.container {
 			float: left;
 			width: 300px;
-			height: 300px;
+			height: 400px;
 			padding: 50px;
 			border-bottom: 0px solid #AEAEAE;
 			background-color: rgba(0, 0, 0, 0.1);
@@ -30,19 +30,21 @@
 <body ng-app="demo" style="min-height: 2000px;">
 
 	<div class="container">
-		<div class="sticky-box" style="background-color: blue; margin: 50px;" media-query="min-width: 768px" sticky>
+		<div class="sticky-box" style="background-color: blue; margin: 50px;" media-query="min-width: 768px" sticky confine="true">
 			Style:<br>
 			margin: 50px;<br>
 			<br>
 			Options:<br>
-			media-query="min-width: 768px"
+			media-query="min-width: 768px"<br>
+			confine="true"
 		</div>
 	</div>
 
 	<div class="container">
-		<div class="sticky-box" style="background-color: blue;" sticky offset="25">
+		<div class="sticky-box" style="background-color: blue;" sticky offset="25" confine="true">
 			Options:<br>
 			offset="25"
+			confine="true"
 		</div>
 	</div>
 

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -14,7 +14,7 @@
 		function linkFn($scope, $elem, $attrs) {
 			var mediaQuery, stickyClass, bodyClass, elem, $window, $body,
 				doc, initialCSS, initialStyle, isPositionFixed, isSticking,
-				stickyLine, offset, anchor, prevOffset, matchMedia, usePlaceholder, placeholder;
+				stickyLine, stickyBottomLine, offset, anchor, confine, prevOffset, matchMedia, usePlaceholder, placeholder;
 
 			isPositionFixed = false;
 			isSticking      = false;
@@ -43,6 +43,11 @@
 			anchor = typeof $attrs.anchor === 'string' ? 
 				$attrs.anchor.toLowerCase().trim() 
 				: 'top';
+            // Define the confine attribute - will confine sticky to it's parent
+            confine = typeof $attrs.confine === 'string' ?
+                $attrs.confine.toLowerCase().trim() : 'false';
+
+            confine = (confine === 'true');
 
 			// initial style
 			initialCSS = {
@@ -116,6 +121,28 @@
 			}, function(newVal, oldVal) {
 				if ( newVal !== oldVal || typeof stickyLine === 'undefined' ) {
 					stickyLine = newVal - offset;
+
+                    // IF the sticky is confined, we want to make sure the parent is relatively positioned, 
+                    // otherwise it won't bottom out properly
+                    
+                    if (confine) {
+                        $elem.parent().css({
+                            'position': 'relative'
+                        });
+                    }
+
+                    // Get Parent height, so we know when to bottom out for confined stickies
+                    var parent = $elem.parent()[0];
+                    console.log(parent.offsetHeight);
+                    var parentHeight = parseInt(parent.offsetHeight);
+
+                    // and now lets ensure we adhere to the bottom margins
+                    // TODO: make this an attribute? Maybe like ignore-margin?
+                    var marginBottom = parseInt($elem.css('margin-bottom').replace(/px;?/, '')) || 0;
+
+                    // specify the bottom out line for the sticky to unstick
+                    stickyBottomLine = parentHeight - (elem.offsetTop + elem.offsetHeight) + offset + marginBottom;
+                    
 					checkIfShouldStick();
 				}
 			});
@@ -126,25 +153,58 @@
 			function checkIfShouldStick() {
 				var scrollTop, shouldStick, scrollBottom, scrolledDistance;
 
-				if ( mediaQuery && !(matchMedia('('+mediaQuery+')').matches || matchMedia(mediaQuery).matches) )
-					return;
+				if ( mediaQuery && !(matchMedia('('+mediaQuery+')').matches || matchMedia(mediaQuery).matches) ){
+                    return;
+                }
 
 				if ( anchor === 'top' ) {
 					scrolledDistance = window.pageYOffset || doc.scrollTop;
 					scrollTop        = scrolledDistance  - (doc.clientTop || 0);
-					shouldStick      = scrollTop >=  stickyLine;
+					if(confine === true){
+                        shouldStick = scrollTop >= stickyLine && scrollTop <= stickyBottomLine
+                    } else {
+                        shouldStick      = scrollTop >=  stickyLine;
+                    }
+
 				} else {
 					scrollBottom     = window.pageYOffset + window.innerHeight;
 					shouldStick      = scrollBottom <= stickyLine;
 				}
 
 				// Switch the sticky mode if the element crosses the sticky line
-				if ( shouldStick && !isSticking )
+				if ( shouldStick && !isSticking ) {
 					stickElement();
-						
-				else if ( !shouldStick && isSticking )
-					unstickElement();
+                } else if ( !shouldStick && isSticking ) {
+                    // could probably do this better
+                    var from, compare, closest;
+                    compare = [stickyLine, stickyBottomLine];
+                    closest = getClosest(compare,scrollTop);
+                    // Check to see if we are closer to the top or bottom confines
+                    // and set from to let the unstick element know the origin
+                    if(closest == stickyLine){
+                        from = 'top';
+                    } else if(closest == stickyBottomLine){
+                        from = 'bottom';
+                    }
+
+					unstickElement(from, scrollTop);
+                }
 			}
+            // Simple helper function to find closest value 
+            // from a set of numbers in an array
+            function getClosest(array, num) {
+                var i = 0;
+                var minDiff = 1000;
+                var ans;
+                for(i in array){
+                    var m = Math.abs(num - array[i]);
+                    if(m < minDiff){
+                        minDiff = m;
+                        ans = array[i];
+                    }
+                }
+                return ans;
+            }
 
 			function stickElement() {
 				var rect, absoluteLeft;
@@ -168,7 +228,10 @@
 					.css('width',      elem.offsetWidth+'px')
 					.css('position',   'fixed')
 					.css(anchor,       offset+'px')
-					.css('left',       absoluteLeft+'px')
+					// This was actually causing a 'jump to the left'
+                    // when using 'left' as absoluteLeft + 'px',
+                    // allowing left to be automatic fixed the issue. 
+                    .css('left',       absoluteLeft)
 					.css('margin-top', 0);
 
 				if ( anchor === 'bottom' ) {
@@ -177,14 +240,16 @@
 
 				//create placeholder to avoid jump
 				if( usePlaceholder ) {
+                    console.log('use placeholder!');
 					placeholder = angular.element("<div>");
 					var elementsHeight = $elem[0].offsetHeight;
 					placeholder.css("height", elementsHeight + "px");
 					$elem.after(placeholder);
 				}
 			}
-
-			function unstickElement() {
+            // Passing in scrolltop and directional origin to help 
+            // with some math later
+			function unstickElement(fromDirection, scrollTop) {
 				$elem.attr('style', $elem.initialStyle);
 				isSticking = false;
 
@@ -196,12 +261,25 @@
 					$elem.removeClass(stickyClass);
 				}
 
-				$elem
-					.css('width',      '')
-					.css('top',        initialCSS.top)
-					.css('position',   initialCSS.position)
-					.css('left',       initialCSS.cssLeft)
-					.css('margin-top', initialCSS.marginTop);
+				if (fromDirection == 'top') {
+                    $elem
+                        .css('width', '')
+                        .css('top', initialCSS.top)
+                        .css('position', initialCSS.position)
+                        .css('left', initialCSS.cssLeft)
+                        .css('margin-top', initialCSS.marginTop);
+
+                } else if (fromDirection == 'bottom' && confine === true) {
+                    // make sure we are checking to see if the element is confined to the parent
+                    $elem
+                        .css('width', '')
+                        .css('top', '')
+                        .css('bottom', 0)
+                        .css('position', 'absolute')
+                        .css('left', initialCSS.cssLeft)
+                        .css('margin-top', initialCSS.marginTop)
+                        .css('margin-bottom', initialCSS.marginBottom);
+                }
 
 				if ( placeholder ) {
 					placeholder.remove();


### PR DESCRIPTION
Great module dude! Was using this at work today, and added a 'confine' attribute, which confines the sticky to it's direct parent node in the DOM, and automatically assigns the parent pos:relative.

I've thought about maybe wrapping the sticky in a relative wrapper, which can then live in an absolute parent, will have to think a bit about the implementation. 

Once again, awesome module, saved me so much time today!