### PR TITLE
fixes broken unstickElement()

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -34,7 +34,7 @@
 
       usePlaceholder = $attrs.useplaceholder == undefined ? false : true;
 
-      initialStyle = $elem.attr('style');
+      initialStyle = $elem.attr('style') || '';
 
       offset = typeof $attrs.offset === 'string' ?
         parseInt($attrs.offset.replace(/px;?/, '')) :
@@ -250,7 +250,7 @@
       // Passing in scrolltop and directional origin to help
       // with some math later
       function unstickElement(fromDirection, scrollTop) {
-        $elem.attr('style', $elem.initialStyle);
+        $elem.attr('style', initialStyle);
         isSticking = false;
 
         if ( bodyClass ) {


### PR DESCRIPTION
Should be self-explanatory. Maybe this was a merge error?

L253: The $elem.initialStyle line 253 referred to isn't set anywhere, the local variable initialStyle wasn't read anywhere. Hooked them up.

L37:  The changed initialStyle initialization makes sure sticky elements without a style attribute still unstick correctly (because given initialStyle == undefined, $elem.attr('style', initialStyle) does the same as $element.attr('style') )