### PR TITLE
reverted left style assignment on unstick as it didn't do anything an…

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -229,10 +229,7 @@
           .css('width',      elem.offsetWidth+'px')
           .css('position',   'fixed')
           .css(anchor,       offset+'px')
-          // This was actually causing a 'jump to the left'
-                    // when using 'left' as absoluteLeft + 'px',
-                    // allowing left to be automatic fixed the issue.
-                    .css('left',       absoluteLeft)
+          .css('left',       absoluteLeft+'px')
           .css('margin-top', 0);
 
         if ( anchor === 'bottom' ) {


### PR DESCRIPTION
Disagreeing with @driannaude on https://github.com/d-oliveros/ngSticky/commit/81eb463e83835a41262fbfdac73d60c2665cffdf

My (floating) sticky elements now loose their horizontal position on stickElement() because assigning just a number via $elem.css('left', aNumberWithoutUnit) will not do anything - the elements jump to the left on sticking, because the left property isn't assigned.

Any thoughts on this, @driannaude? Why exactly has this been introduced? How can we keep my applications working while not destroying the bottom-out feature?