### PR TITLE
Sticky line and useplaceholder bugfix

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -121,7 +121,7 @@
       prevOffset = _getTopOffset(elem);
 
       $scope.$watch( function() { // triggered on load and on digest cycle
-        if ( isSticking ) return prevOffset;
+        if ( isSticking ) return prevOffset + getScrollTop();
 
         prevOffset =
           (anchor === 'top') ?

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -3,6 +3,18 @@
 
   var module = angular.module('sticky', []);
 
+  function getScrollTop(){
+    if(typeof window.pageYOffset !== 'undefined'){
+        //most browsers except IE before #9
+        return window.pageYOffset;
+    }
+    else{
+        var B = document.body; //IE 'quirks'
+        var D = document.documentElement; //IE with doctype
+        D = (D.clientHeight) ? D : B;
+        return D.scrollTop;
+    }
+  }
   // Directive: sticky
   //
   module.directive('sticky', function() {
@@ -116,10 +128,10 @@
             _getTopOffset(elem) :
             _getBottomOffset(elem);
 
-        return prevOffset;
+        return prevOffset + getScrollTop();
 
       }, function(newVal, oldVal) {
-        if (( newVal !== oldVal || typeof stickyLine === 'undefined' ) && newVal !== 0) {
+        if (( newVal !== oldVal || typeof stickyLine === 'undefined' ) && newVal !== 0 && !isSticking) {
           stickyLine = newVal - offset;
 
           // IF the sticky is confined, we want to make sure the parent is relatively positioned,
@@ -232,9 +244,17 @@
             $elem.removeClass(unstickyClass);
           }
         }
-          
+
         if ( stickyClass ) {
           $elem.addClass(stickyClass);
+        }
+
+        //create placeholder to avoid jump
+        if( usePlaceholder ) {
+          placeholder = angular.element("<div>");
+          var elementsHeight = $elem[0].offsetHeight;
+          placeholder.css("height", elementsHeight + "px");
+          $elem.after(placeholder);
         }
 
         $elem
@@ -246,14 +266,6 @@
 
         if ( anchor === 'bottom' ) {
           $elem.css('margin-bottom', 0);
-        }
-
-        //create placeholder to avoid jump
-        if( usePlaceholder ) {
-          placeholder = angular.element("<div>");
-          var elementsHeight = $elem[0].offsetHeight;
-          placeholder.css("height", elementsHeight + "px");
-          $elem.after(placeholder);
         }
       }
       // Passing in scrolltop and directional origin to help


### PR DESCRIPTION
The main problem with using placeholder was that if the viewport height was just a little smaller than the content height, that after sticking (applying `position: fixed`) to our element the scrollbar disappeared, and  after that the directive added the placeholder element, the scrollbar position didn't return to it's original position. The answear is to first add the placeholder element and only then apply `position: fixed` to the original one.

Also calculating top offset for the sticky element was buggy as `getBoundingClientRect` doesn't take into account tha main window scrollbar position.