### PR TITLE
Take margins into account when measuring the placeholder

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -194,7 +194,7 @@
             //create placeholder to avoid jump
             if (usePlaceholder) {
               placeholder = angular.element('<div>');
-              var elementsHeight = $elem[0].offsetHeight;
+              var elementsHeight = $elem.outerHeight(true);
               placeholder.css('height', elementsHeight + 'px');
               $elem.after(placeholder);
             }

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -194,7 +194,12 @@
             //create placeholder to avoid jump
             if (usePlaceholder) {
               placeholder = angular.element('<div>');
-              var elementsHeight = $elem.outerHeight(true);
+              var elementsHeight = $elem[0].offsetHeight;
+              var computedStyle = $elem[0].currentStyle || window.getComputedStyle($elem[0]);
+              elementsHeight += parseInt(computedStyle.marginTop, 10);
+              elementsHeight += parseInt(computedStyle.marginBottom, 10);
+              elementsHeight += parseInt(computedStyle.borderTopWidth, 10);
+              elementsHeight += parseInt(computedStyle.borderBottomWidth, 10);
               placeholder.css('height', elementsHeight + 'px');
               $elem.after(placeholder);
             }


### PR DESCRIPTION
Now when the sticky element has top or bottom margins, there is no jump at all!