### PR TITLE
Added disableSticky functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ as a dependency. Use the directive as follows:
 
     <div sticky> Hey there! </div>
 
+To toggle the element stickiness you can bind with scope using the disable-sticky (ng-model) as follows {{ disabled = true }}: 
+    
+    <div sticky disable-sticky="disabled"> I won't stick! </div>
+    <div sticky disable-sticky="!disabled"> I will stick! </div>
+
 To make the element stick within a certain offset of the top of the screen, you can provide an offset as follows:
 
     <div sticky offset="100"> I won't touch the top of your screen! </div>

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -27,7 +27,7 @@
 	</style>
 </head>
 
-<body ng-app="demo" style="min-height: 2000px;">
+<body ng-app="demo" style="min-height: 2000px;" ng-controller="demoCtrl">
 
 	<div class="container">
 		<div class="sticky-box" style="background-color: blue; margin: 50px;" media-query="min-width: 768px" sticky confine="true">
@@ -55,6 +55,15 @@
 		top: 400px;
 	</div>
 
+	<div class="sticky-box" style="position: absolute; top: 600px; left: 600px; background-color: grey;" sticky disabled-sticky="disableSticking">
+		Optional Sticky<br>
+		Style:<br>
+		position: absolute;<br>
+		left: 600px;<br>
+		top: 600px;
+		<button type="button" ng-click="disableSticking = !disableSticking" >Disable Sticking? {{ disableSticking }}</button>
+	</div>
+
 	<div style="height: 1200px;"></div>
 
 	<div class="sticky-box" style="background-color: green; margin: 50px;" sticky anchor="bottom" offset="0">
@@ -79,7 +88,10 @@
 	<aside role="scripts">
 		<script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.20/angular.min.js"></script>
 		<script src="../lib/sticky.js"></script>
-		<script>angular.module('demo', ['sticky']);</script>
+		<script>angular.module('demo', ['sticky']).controller('demoCtrl', function($scope) {
+					$scope.disableSticking = false;
+				});
+		</script>
 	</aside>
 
 </body>

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -8,6 +8,9 @@
   module.directive('sticky', ['$window', function ($window) {
       return {
         restrict: 'A', // this directive can only be used as an attribute.
+        scope: {
+          disabled: '=disabledSticky'
+        },
         link: function linkFn($scope, $elem, $attrs) {
           var mediaQuery, stickyClass, unstickyClass, bodyClass, elem, $body,
             doc, initialCSS, initialStyle, isSticking,
@@ -213,6 +216,11 @@
           };
 
           $scope.checkIfShouldStick = function () {
+            if ($scope.disabled === true){
+              $scope.unStickElement();
+              return false;
+            }
+
             var scrollTop, shouldStick, scrollBottom, scrolledDistance;
 
             if (mediaQuery && !(matchMedia('(' + mediaQuery + ')').matches || matchMedia(mediaQuery).matches)) {
@@ -307,6 +315,11 @@
 
           $scope.$watch(function () {
             // triggered on load and on digest cycle
+            if ($scope.disabled === true){
+              $scope.unStickElement();
+              return;
+            }
+
             if (isSticking) {
               return prevOffset + $scope.getScrollTop();
             }


### PR DESCRIPTION
Update directive for disableSticky ng-model functionality. For Issue #33.
Changes to sticky.js to include an ng-model binding for disableSticky to disable sticky behavior
Changes to demo.html to test disable-sticky.js.
Changes to Readme.txt to describe the disable-sticky functionality.

Please review and let me know if I missed something. I didn't see any tests or wiki on proper submissions.