### PR TITLE
preliminary sticky support on scrollable DIVs

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -12,9 +12,10 @@
           disabled: '=disabledSticky'
         },
         link: function linkFn($scope, $elem, $attrs) {
-          var mediaQuery, stickyClass, unstickyClass, bodyClass, elem, $body,
+          var mediaQuery, stickyClass, unstickyClass, bodyClass, elem, $body, scrollingViewport, isScrollHeightObserved,
             doc, initialCSS, initialStyle, isSticking,
             stickyLine, stickyBottomLine, offset, anchor, confine, prevOffset, matchMedia, usePlaceholder, placeholder;
+
 
           $scope.initSticky = function () {
             isSticking = false;
@@ -31,6 +32,10 @@
             stickyClass = $attrs.stickyClass || '';
             unstickyClass = $attrs.unstickyClass || '';
             bodyClass = $attrs.bodyClass || '';
+            // allows for an alternate scrollable DIV element having overflow, defaults to browser window
+            scrollingViewport = $scope.deriveScrollingViewport( $attrs.scrollingParentSelector );
+            // hint that the content may be so dynamic that it affects the scrollable height of the container
+            isScrollHeightObserved = $attrs.isScrollHeightObserved.trim() === 'true';
 
             usePlaceholder = $attrs.useplaceholder !== undefined;
 
@@ -74,16 +79,38 @@
 
             // Listeners
             //
-            angular.element($window).on('scroll', $scope.checkIfShouldStick);
-            angular.element($window).on('resize', $scope.$apply.bind($scope, $scope.onResize));
+            angular.element( scrollingViewport).on('scroll', $scope.checkIfShouldStick);
+            angular.element( $window).on('resize', $scope.$apply.bind($scope, $scope.onResize));
+
+            // optional observer on the content pane's scrollable height
+            if ( $attrs.scrollingParentSelector && scrollingViewport ) {
+
+              var onScrollingViewportScrollHeightChangedUnbind = $scope.$watch(
+                  function(){ return scrollingViewport.scrollHeight },
+                  $scope.onScrollingViewportScrollHeightChanged
+              );
+
+              //angular.element( scrollingViewport).on('resize', $scope.$apply.bind($scope, $scope.onResize));
+            }
+
+            //angular.element( $window).on('resize', $scope.$apply.bind($scope, $scope.onResize));
             $scope.$on('$destroy', $scope.onDestroy);
+
+
+
+
+
           };
 
           $scope.getScrollTop = function () {
-            if (typeof $window.pageYOffset !== 'undefined') {
+            //if (typeof window.pageYOffset !== 'undefined') {
+            if (typeof scrollingViewport.scrollTop !== 'undefined') {
               //most browsers except IE before #9
-              return $window.pageYOffset;
+              //return $window.pageYOffset;
+              return scrollingViewport.scrollTop;
             }
+
+            // i didn't compensate for this dying browser.. don't care either
             else {
               var B = document.body; //IE 'quirks'
               var D = document.documentElement; //IE with doctype
@@ -95,6 +122,7 @@
           $scope.getTopOffset = function (element) {
             if (element.getBoundingClientRect) {
               // Using getBoundingClientRect is vastly faster, if it's available
+
               return element.getBoundingClientRect().top + document.documentElement.scrollTop;
             } else {
               var pixels = 0;
@@ -117,7 +145,11 @@
           $scope.shouldStickWithLimit = function (shouldApplyWithLimit) {
             if (shouldApplyWithLimit === 'true') {
               var elementHeight = elem.offsetHeight;
-              var windowHeight = $window.innerHeight;
+
+              //var windowHeight = $window.innerHeight;
+              var windowHeight = scrollingViewport.innerHeight;
+              console.log("win height", windowHeight);
+
               return (windowHeight - (elementHeight + parseInt(offset)) < 0);
             } else {
               return false;
@@ -139,9 +171,22 @@
             }
           };
 
+          // 20151005 - adjust calculations each time the scrollable height ( contents inside pane ) change
+          // usually due to content being dynamically modified
+             $scope.onScrollingViewportScrollHeightChanged = function(newValue, oldValue) {
+               // not sure which calculation is 'best', so reusing onResize magic
+               $scope.onResize();
+            };
+
+
           $scope.onDestroy = function () {
-            angular.element($window).off('scroll', $scope.checkIfShouldStick);
-            angular.element($window).off('resize', $scope.onResize);
+            angular.element( scrollingViewport ).off('scroll', $scope.checkIfShouldStick);
+            angular.element( $window ).off('resize', $scope.onResize);
+
+            // unwatch optionally bound function
+            if ( onScrollingViewportScrollHeightChangedUnbind ) {
+              onScrollingViewportScrollHeightChangedUnbind();
+            }
 
             if (bodyClass) {
               $body.removeClass(bodyClass);
@@ -227,7 +272,10 @@
             }
 
             if (anchor === 'top') {
-              scrolledDistance = $window.pageYOffset || doc.scrollTop;
+
+              //scrolledDistance = $window.pageYOffset || doc.scrollTop;
+              scrolledDistance = scrollingViewport.scrollTop || doc.scrollTop;
+
               scrollTop = scrolledDistance - (doc.clientTop || 0);
               if (confine === true) {
                 shouldStick = scrollTop >= stickyLine && scrollTop <= stickyBottomLine;
@@ -236,7 +284,10 @@
               }
 
             } else {
-              scrollBottom = $window.pageYOffset + $window.innerHeight;
+
+             // scrollBottom = $window.pageYOffset + $window.innerHeight;
+              scrollBottom = scrollingViewport.pageYOffset + scrollingViewport.innerHeight;
+
               shouldStick = scrollBottom <= stickyLine;
             }
 
@@ -353,6 +404,32 @@
               $scope.checkIfShouldStick();
             }
           });
+
+
+          // 20151004 - mattmutt - optionally gets the user defined element that handles scrolling
+          $scope.deriveScrollingViewport = function( ancestorSelector ) {
+            if ( !ancestorSelector ) {
+              return $window;
+            }
+
+            // derive relevant scrolling by ascending the DOM tree 'n' levels from source element
+            var match = $elem.closest( ancestorSelector );
+
+            if ( match.length === 1 ) {
+              return match.get(0);
+            }
+            // faulty selector supplied, assume that immediate parent is the intended container
+            // please change it to something better, exception or $window
+            else {
+              return $elem.parent().get(0);
+            }
+
+          };
+
+
+
+
+
 
           // Init the directive
           $scope.initSticky();


### PR DESCRIPTION
I like this project's original implementation, but it lacked the ability for me to have sticky elements on DIV containers that were scrollable. In my app the scrolling sections are not on the entire BODY but rather predefined <DIV>-based viewports that have their `overflow` turned on.

Added two attributes that could be supplied to the directive:

`scrolling-parent-selector`
A selector-style syntax that scans up the DOM tree to finding the DIV that is responsible for the scrolling. This is nice loose coupling. Don't want to assume its just the immediate parentNode. An example might be `.myScrollClass`  if you have a container like `<DIV class="myScrollClass">`

`is-scroll-height-observed`
This flag is needed in the case where the scrollable content changes its content, which in turn triggers a change in the total scrollable height of the above mentioned scrolling viewport. For example I have an expandable tree inside. I was sure which calculations need to be performed, so I reused the one from onResize ( of the web browser ). Hopefully that is "good enough"

*I didn't do comprehensive testing*, perhaps some others can take this idea further? 

In this image, you can see it working in my local environment. There are two states - basically scrolled to the top of the DIV, and then in 2. slight vertical downward scrolling - you can see the "Demo" title gets pinned correctly. Anyways this solutions works well for my use case. I am sure others would want to have some way of putting sticky items inside DIVs anywhere on the page.

![sticky-scrollable-div](https://cloud.githubusercontent.com/assets/8688570/10296145/c3a4dc2a-6b7a-11e5-9102-eead2e3863ed.png)

