### PR TITLE
Correct typo: disabled-sticky not disable-sticky

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ as a dependency. Use the directive as follows:
 
     <div sticky> Hey there! </div>
 
-To toggle the element stickiness you can bind with scope using the disable-sticky (ng-model) as follows {{ disabled = true }}: 
+To toggle the element stickiness you can bind with scope using the disabled-sticky (ng-model) as follows {{ disabled = true }}: 
     
-    <div sticky disable-sticky="disabled"> I won't stick! </div>
-    <div sticky disable-sticky="!disabled"> I will stick! </div>
+    <div sticky disabled-sticky="disabled"> I won't stick! </div>
+    <div sticky disabled-sticky="!disabled"> I will stick! </div>
 
 To make the element stick within a certain offset of the top of the screen, you can provide an offset as follows:
 


### PR DESCRIPTION
In the README.md file, the `disabled-sticky` attribute is wrongly documented as `disable-sticky`.