### PR TITLE
Wrapped the initial css setup in a $timeout

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -509,9 +509,11 @@
 
           // ----------- configuration -----------
 
-          var originalInitialCSS = $scope.calculateStickyContentInitialDimensions (); // preserve a copy
-          // Init the directive
-          initSticky ();
+          $timeout( function() {
+            var originalInitialCSS = $scope.calculateStickyContentInitialDimensions(); // preserve a copy
+            // Init the directive
+            initSticky();
+          },0);
         },
 
         /**


### PR DESCRIPTION
Fixes an issue where the css could be initialized before the page was fully rendered.