### PR TITLE
Fix jumping on media-query.

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -113,8 +113,9 @@
            */
           var checkIfShouldStick = function() {
             // Check media query and disabled attribute
-            if (($scope.disabled === true || mediaQueryMatches ()) && isSticking) {
-              return unStickElement ();
+            if ($scope.disabled === true || mediaQueryMatches ()) {
+              if(isSticking) unStickElement ();
+              return false;
             }
 
             // What's the document client top for?


### PR DESCRIPTION
v1.8.6 checks to see if a media-query matches `&&` the container is stuck...if so, it unsticks the container. This causes a lot of jumping back and forth. This PR checks to see if a media-query is matched, then it aborts and, if the container is stuck, unsticks the container.

Fixes issue #96.