### PR TITLE
fix (initialCSS) update the stocked dimensions of sticky element

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -56,19 +56,28 @@
           // initial style
           var initialStyle = $elem.attr('style') || '';
           var initialCSS;
+          /**
+           * Trigger to initialize the sticky
+           * Because of the `timeout()` method for the call of `initSticky()` method, the `onChange` method is called before!
+           * @type {Boolean}
+           */
+          var toInitialize = true;
 
           /**
            * Initialize Sticky
            */
           var initSticky = function() {
-            // Listeners
-            scrollbarElement.on('scroll', checkIfShouldStick);
-            windowElement.on('resize', $scope.$apply.bind($scope, onResize));
+            if( toInitialize ){
+              // Listeners
+              scrollbarElement.on('scroll', checkIfShouldStick);
+              windowElement.on('resize', $scope.$apply.bind($scope, onResize));
 
-            memorizeDimensions (); // remember sticky's layout dimensions
+              memorizeDimensions (); // remember sticky's layout dimensions
 
-            // Clean up
-            $scope.$on('$destroy', onDestroy);
+              // Clean up
+              $scope.$on('$destroy', onDestroy);
+              toInitialize = false;
+            }
           };
 
           /**
@@ -347,7 +356,7 @@
               stickyLine = newVal - offset;
               //Update dimensions of sticky element when is showed
               if( elemIsShowed && elemWasHidden ){
-                $scope.updateStickyContentUpdateDimensions( $elem[0].offsetWidth, $elem.css('height') )
+                $scope.updateStickyContentUpdateDimensions( $elem[0].offsetWidth, $elem[0].offsetHeight );
               }
               // IF the sticky is confined, we want to make sure the parent is relatively positioned,
               // otherwise it won't bottom out properly
@@ -505,6 +514,9 @@
            */
           $scope.updateStickyContentUpdateDimensions = function(width, height) {
             if (width && height) {
+              if( toInitialize ){
+                initSticky();
+              }
               initialCSS.width = width + "px";
               initialCSS.height = height + "px";
               // if a dimensionless pair of arguments was supplied.

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -230,7 +230,7 @@
 
               $elem
                   .css('z-index', 10)
-                  .css('width', $elem[0].offsetWidth)
+                  .css('width', initialCSS.width)
                   .css('top', initialCSS.top)
                   .css('position', initialCSS.position)
                   .css('left', initialCSS.cssLeft)
@@ -245,7 +245,7 @@
 
               $elem
                   .css('z-index', 10)
-                  .css('width', $elem[0].offsetWidth)
+                  .css('width', initialCSS.width)
                   .css('top', '')
                   .css('bottom', 0)
                   .css('position', 'absolute')
@@ -331,10 +331,19 @@
            * Triggered on change
            */
           var onChange = function (newVal, oldVal) {
+            var
+              /**
+               * Indicate if the DOM element is showed, or not
+               * @type {boolean}
+               */
+              elemIsShowed = !!newVal;
             if (( newVal !== oldVal || typeof stickyLine === 'undefined' ) &&
-              (!isSticking && !isBottomedOut())) {
+              (!isSticking && !isBottomedOut()) && elemIsShowed) {
               stickyLine = newVal - offset;
-
+              //Update dimensions of sticky element when is showed
+              if( elemIsShowed ){
+                $scope.updateStickyContentUpdateDimensions( $elem.css('width'), $elem.css('height') )
+              }
               // IF the sticky is confined, we want to make sure the parent is relatively positioned,
               // otherwise it won't bottom out properly
               if (confine) {
@@ -481,6 +490,7 @@
               marginTop: $elem.css('margin-top'),
               marginBottom: $elem.css('margin-bottom'),
               cssLeft: $elem.css('left'),
+              width: $elem.css('width'),
               height: $elem.css('height')
             };
           };

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -342,7 +342,7 @@
               stickyLine = newVal - offset;
               //Update dimensions of sticky element when is showed
               if( elemIsShowed ){
-                $scope.updateStickyContentUpdateDimensions( $elem.css('width'), $elem.css('height') )
+                $scope.updateStickyContentUpdateDimensions( $elem[0].offsetWidth, $elem.css('height') )
               }
               // IF the sticky is confined, we want to make sure the parent is relatively positioned,
               // otherwise it won't bottom out properly
@@ -490,7 +490,7 @@
               marginTop: $elem.css('margin-top'),
               marginBottom: $elem.css('margin-bottom'),
               cssLeft: $elem.css('left'),
-              width: $elem.css('width'),
+              width: $elem[0].offsetWidth,
               height: $elem.css('height')
             };
           };

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -323,16 +323,20 @@
 
           /**
            * Triggered on load / digest cycle
+           * return `0` if the DOM element is hidden
            */
           var onDigest = function() {
             if ($scope.disabled === true) {
               return unStickElement ();
             }
-
+            var offsetFromTop = elementsOffsetFromTop ($elem[0]);
+            if(offsetFromTop === 0){
+              return offsetFromTop;
+            }
             if (anchor === 'top') {
-              return (originalOffset || elementsOffsetFromTop ($elem[0])) - elementsOffsetFromTop (scrollbar) + scrollbarYPos ();
+              return (originalOffset || offsetFromTop) - elementsOffsetFromTop (scrollbar) + scrollbarYPos ();
             } else {
-              return elementsOffsetFromTop ($elem[0]) - scrollbarHeight () + $elem[0].offsetHeight + scrollbarYPos ();
+              return offsetFromTop - scrollbarHeight () + $elem[0].offsetHeight + scrollbarYPos ();
             }
           };
 

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -336,12 +336,17 @@
                * Indicate if the DOM element is showed, or not
                * @type {boolean}
                */
-              elemIsShowed = !!newVal;
+              elemIsShowed = !!newVal,
+              /**
+               * Indicate if the DOM element was showed, or not
+               * @type {boolean}
+               */
+              elemWasHidden = !oldVal;
             if (( newVal !== oldVal || typeof stickyLine === 'undefined' ) &&
               (!isSticking && !isBottomedOut()) && elemIsShowed) {
               stickyLine = newVal - offset;
               //Update dimensions of sticky element when is showed
-              if( elemIsShowed ){
+              if( elemIsShowed && elemWasHidden ){
                 $scope.updateStickyContentUpdateDimensions( $elem[0].offsetWidth, $elem.css('height') )
               }
               // IF the sticky is confined, we want to make sure the parent is relatively positioned,


### PR DESCRIPTION
When the sticky element is hidden on loading, the `initialCSS` is not correctly
settled
see [example](http://jsfiddle.net/cdaabdoy/)

#112 