### PR TITLE
Update bower version to match the github tag

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ngSticky",
-  "version": "1.8.4",
+  "version": "1.8.7",
   "homepage": "https://github.com/d-oliveros/ngSticky",
   "authors": [
     "David Oliveros <dato.oliveros@gmail.com>",


### PR DESCRIPTION
This should avoid warnings when running bower update.