### PR TITLE
Update sticky.js

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -74,6 +74,19 @@
           var offset = $attrs.offset
             ? parseInt ($attrs.offset.replace(/px;?/, ''))
             : 0;
+            
+            $elem.GetOffSet=function() {
+      				try {return this.offset();} catch(e) {}
+      				var rawDom = elm[0];
+      				var _x = 0;
+      				var _y = 0;
+      				var body = document.documentElement || document.body;
+      				var scrollX = window.pageXOffset || body.scrollLeft;
+      				var scrollY = window.pageYOffset || body.scrollTop;
+      				_x = rawDom.getBoundingClientRect().left + scrollX;
+      				_y = rawDom.getBoundingClientRect().top + scrollY;
+      				return { left: _x, top: _y };
+      			};
 
           /**
            * Trigger to initialize the sticky
@@ -305,8 +318,8 @@
             $elem
               .css('z-index', '10')
               .css('width', $elem[0].offsetWidth + 'px')
+			        .css('left', $elem.GetOffSet().left + 'px')
               .css('position', 'fixed')
-              .css('left', $elem.css('left').replace('px', '') + 'px')
               .css(anchor, (offset + elementsOffsetFromTop (scrollbar)) + 'px')
               .css('margin-top', 0);
 


### PR DESCRIPTION
the suggested updates are to fix an issue where the object unstick itself and then resticks itself. it was not calculating the left position correctly.  This has it calculate its position from the left side of the browser.  Which is where the fixed element is probably going to calculate from.