### PR TITLE
Use the correct variable to set the height of the placeholder

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -441,7 +441,7 @@
               elementsHeight += parseInt(computedStyle.marginBottom, 10);
               elementsHeight += parseInt(computedStyle.borderTopWidth, 10);
               elementsHeight += parseInt(computedStyle.borderBottomWidth, 10);
-              placeholder.css('height', $elem[0].offsetHeight + 'px');
+              placeholder.css('height', elementsHeight + 'px');
 
               $elem.after(placeholder);
             }


### PR DESCRIPTION
The height is calculated in a variable but this variable was not used to set the height of the placeholder.
Just put the correct variable.