### PR TITLE
Update sticky.js

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -247,6 +247,8 @@
             $elem.attr('style', initialStyle);
             isSticking = false;
 
+            initialCSS.width = $scope.getInitialDimensions().width;
+
             $body.removeClass(bodyClass);
             $elem.removeClass(stickyClass);
             $elem.addClass(unstickyClass);


### PR DESCRIPTION
Fix element width after resize.

Element width is being calculated properly in `stickElement()`, but `unstickElement()` keeps (re)setting initial width, which caused problems if browser was resized.