### PR TITLE
Placeholder fix for margin and border inclusion in height calculation

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -451,7 +451,7 @@
               elementsHeight += parseInt(computedStyle.marginBottom, 10);
               elementsHeight += parseInt(computedStyle.borderTopWidth, 10);
               elementsHeight += parseInt(computedStyle.borderBottomWidth, 10);
-              placeholder.css('height', $elem[0].offsetHeight + 'px');
+              placeholder.css('height', elementsHeight + 'px');
 
               $elem.after(placeholder);
             }


### PR DESCRIPTION
Calculated Placeholder height which included margin top/bottom and border top/bottom was not being used for placeholder css height property.