### PR TITLE
Support for configuring custom scrollable node

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -23,7 +23,7 @@
         link: function linkFn($scope, $elem, $attrs) {
 
           // Initial scope
-          var scrollableNodeTagName = 'sticky-scroll';
+          var scrollableNodeTagName = $attrs.containerClass || 'sticky-scroll';
           var initialPosition = $elem.css('position');
           var initialStyle = $elem.attr('style') || '';
           var stickyBottomLine = 0;

--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -23,7 +23,7 @@
         link: function linkFn($scope, $elem, $attrs) {
 
           // Initial scope
-          var scrollableNodeTagName = $attrs.containerClass || 'sticky-scroll';
+          var scrollableNodeTagName = $attrs.scrollingElement || 'sticky-scroll';
           var initialPosition = $elem.css('position');
           var initialStyle = $elem.attr('style') || '';
           var stickyBottomLine = 0;


### PR DESCRIPTION
In the case of using existing scrollable elements like <md-content>, it would be nice to bind the sticky element to that element instead of the <sticky-scroll>element. Using this new optional attribute: scrolling-element, you can specify a different element to bind to. 